### PR TITLE
Add support for passing keyword arguments in an object to high state.

### DIFF
--- a/salt/state.py
+++ b/salt/state.py
@@ -1136,6 +1136,14 @@ class State(object):
                         .format(name, body['__sls__'], state)
                     )
                     continue
+                if isinstance(body[state], dict):
+                    # Convert the dict to an array of key/value pairs.
+                    args = []
+                    for key, value in six.iteritems(body[state]):
+                        arg = {}
+                        arg[key] = value
+                        args.append(arg)
+                    body[state] = args
                 if not isinstance(body[state], list):
                     errors.append(
                         'State \'{0}\' in SLS \'{1}\' is not formed as a list'


### PR DESCRIPTION
### What does this PR do?

Add support for passing keyword arguments in a object to salt states similar to salt modules.

### Previous Behavior

High state currently requires the state body to be an array of key/value pair objects. This a poor design when using JSON.

### New Behavior

Add support for passing keyword arguments in a object to salt states similar to salt modules. Convert the object to the expected array of key/value pairs.

### Tests written?

No

### Commits signed with GPG?

No
